### PR TITLE
Fix urls (krlmlr -> r-lib)

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -30,7 +30,7 @@ knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
 
 This works, regardless of where the associated source file lives inside your project. These paths will also "just work" during interactive development, without incessant fiddling with the working directory of your IDE's R process.
 
-`here::here()` works like `file.path()`, but where the path root is implicitly set to "the path to the top-level of my current project". See [The Fine Print](#the-fine-print) for the underlying heuristics. If they don't suit, use the more powerful package [rprojroot](https://krlmlr.github.io/rprojroot/) directly. Both [here](https://krlmlr.github.io/here/) and [rprojroot](https://krlmlr.github.io/rprojroot/) are written by [Kirill Müller](https://github.com/krlmlr) and are available on CRAN.
+`here::here()` works like `file.path()`, but where the path root is implicitly set to "the path to the top-level of my current project". See [The Fine Print](#the-fine-print) for the underlying heuristics. If they don't suit, use the more powerful package [rprojroot](https://github.com/r-lib/rprojroot) directly. Both [here](https://github.com/r-lib/here) and [rprojroot](https://github.com/r-lib/rprojroot) are written by [Kirill Müller](https://github.com/krlmlr) and are available on CRAN.
 
 ## Admitting you have a problem
 
@@ -84,4 +84,4 @@ Here are the criteria. The order doesn't really matter because all of them are c
   * Is this a [projectile](http://projectile.readthedocs.io/en/latest/) project? Does it have a file named `.projectile`?
   * Is this a checkout from a version control system? Does it have a directory named `.git` or `.svn`? Currently, only Git and Subversion are supported.
 
-If no criteria match, the current working directory will be used as fallback. Use `set_here()` to create an empty `.here` file that will stop the search if none of the other criteria apply. `dr_here()` will attempt to explain why `here` decided the root location the way it did. See the [function reference](https://krlmlr.github.io/here/reference/here.html) for more detail.
+If no criteria match, the current working directory will be used as fallback. Use `set_here()` to create an empty `.here` file that will stop the search if none of the other criteria apply. `dr_here()` will attempt to explain why `here` decided the root location the way it did. See the [function reference](https://r-lib.github.io/here/reference/here.html) for more detail.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ TL;DR
 
 This works, regardless of where the associated source file lives inside your project. These paths will also "just work" during interactive development, without incessant fiddling with the working directory of your IDE's R process.
 
-`here::here()` works like `file.path()`, but where the path root is implicitly set to "the path to the top-level of my current project". See [The Fine Print](#the-fine-print) for the underlying heuristics. If they don't suit, use the more powerful package [rprojroot](https://krlmlr.github.io/rprojroot/) directly. Both [here](https://krlmlr.github.io/here/) and [rprojroot](https://krlmlr.github.io/rprojroot/) are written by [Kirill Müller](https://github.com/krlmlr) and are available on CRAN.
+`here::here()` works like `file.path()`, but where the path root is implicitly set to "the path to the top-level of my current project". See [The Fine Print](#the-fine-print) for the underlying heuristics. If they don't suit, use the more powerful package [rprojroot](https://github.com/r-lib/rprojroot) directly. Both [here](https://github.com/r-lib/here) and [rprojroot](https://github.com/r-lib/rprojroot) are written by [Kirill Müller](https://github.com/krlmlr) and are available on CRAN.
 
 Admitting you have a problem
 ----------------------------
@@ -90,4 +90,4 @@ Here are the criteria. The order doesn't really matter because all of them are c
 -   Is this a [projectile](http://projectile.readthedocs.io/en/latest/) project? Does it have a file named `.projectile`?
 -   Is this a checkout from a version control system? Does it have a directory named `.git` or `.svn`? Currently, only Git and Subversion are supported.
 
-If no criteria match, the current working directory will be used as fallback. Use `set_here()` to create an empty `.here` file that will stop the search if none of the other criteria apply. `dr_here()` will attempt to explain why `here` decided the root location the way it did. See the [function reference](https://krlmlr.github.io/here/reference/here.html) for more detail.
+If no criteria match, the current working directory will be used as fallback. Use `set_here()` to create an empty `.here` file that will stop the search if none of the other criteria apply. `dr_here()` will attempt to explain why `here` decided the root location the way it did. See the [function reference](https://r-lib.github.io/here/reference/here.html) for more detail.


### PR DESCRIPTION
Links to `krlmlr`'s github projects do not work anymore. Seems like the repository has been transferred to `r-lib`.  I've updated the links in the `Rmd` file and re-rendered the `md` so they end up pointing to the correct location.