### PR TITLE
Update links to here package

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -15,7 +15,7 @@ knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
 
 ## TL;DR
 
-1. Install [here](https://krlmlr.github.io/here/).
+1. Install [here](https://github.com/r-lib/here).
 
     ```{r eval = FALSE}
     install.packages("here")
@@ -30,7 +30,7 @@ knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
 
 This works, regardless of where the associated source file lives inside your project. These paths will also "just work" during interactive development, without incessant fiddling with the working directory of your IDE's R process.
 
-`here::here()` works like `file.path()`, but where the path root is implicitly set to "the path to the top-level of my current project". See [The Fine Print](#the-fine-print) for the underlying heuristics. If they don't suit, use the more powerful package [rprojroot](https://krlmlr.github.io/rprojroot/) directly. Both [here](https://krlmlr.github.io/here/) and [rprojroot](https://krlmlr.github.io/rprojroot/) are written by [Kirill Müller](https://github.com/krlmlr) and are available on CRAN.
+`here::here()` works like `file.path()`, but where the path root is implicitly set to "the path to the top-level of my current project". See [The Fine Print](#the-fine-print) for the underlying heuristics. If they don't suit, use the more powerful package [rprojroot](https://github.com/r-lib/rprojroot) directly. Both [here](https://github.com/r-lib/here) and [rprojroot](https://github.com/r-lib/rprojroot) are written by [Kirill Müller](https://github.com/krlmlr) and are available on CRAN.
 
 ## Admitting you have a problem
 
@@ -86,4 +86,4 @@ Here are the criteria. The order doesn't really matter because all of them are c
   * Is this a [projectile](http://projectile.readthedocs.io/en/latest/) project? Does it have a file named `.projectile`?
   * Is this a checkout from a version control system? Does it have a directory named `.git` or `.svn`? Currently, only Git and Subversion are supported.
 
-If no criteria match, the current working directory will be used as fallback. Use `set_here()` to create an empty `.here` file that will stop the search if none of the other criteria apply. `dr_here()` will attempt to explain why `here` decided the root location the way it did. See the [function reference](https://krlmlr.github.io/here/reference/here.html) for more detail.
+If no criteria match, the current working directory will be used as fallback. Use `set_here()` to create an empty `.here` file that will stop the search if none of the other criteria apply. `dr_here()` will attempt to explain why `here` decided the root location the way it did. See the [function reference](https://github.com/r-lib/here/blob/master/R/here.R) for more detail.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## TL;DR
 
-1.  Install [here](https://krlmlr.github.io/here/).
+1.  Install [here](https://github.com/r-lib/here).
     
     ``` r
     install.packages("here")
@@ -27,9 +27,9 @@ your IDE’s R process.
 implicitly set to “the path to the top-level of my current project”. See
 [The Fine Print](#the-fine-print) for the underlying heuristics. If they
 don’t suit, use the more powerful package
-[rprojroot](https://krlmlr.github.io/rprojroot/) directly. Both
-[here](https://krlmlr.github.io/here/) and
-[rprojroot](https://krlmlr.github.io/rprojroot/) are written by [Kirill
+[rprojroot](https://github.com/r-lib/rprojroot) directly. Both
+[here](https://github.com/r-lib/here) and
+[rprojroot](https://github.com/r-lib/rprojroot) are written by [Kirill
 Müller](https://github.com/krlmlr) and are available on CRAN.
 
 ## Admitting you have a problem
@@ -74,16 +74,16 @@ displays this on load or, at any time, you can just call `here()`.
 
 ``` r
 library(here)
-#> here() starts at /Users/jenny/rrr/here_here
+#> here() starts at /Users/amanda/Desktop/Projects/here_here
 here()
-#> [1] "/Users/jenny/rrr/here_here"
+#> [1] "/Users/amanda/Desktop/Projects/here_here"
 ```
 
 Build a path to something in a subdirectory and use it.
 
 ``` r
 here("one", "two", "awesome.txt")
-#> [1] "/Users/jenny/rrr/here_here/one/two/awesome.txt"
+#> [1] "/Users/amanda/Desktop/Projects/here_here/one/two/awesome.txt"
 cat(readLines(here("one", "two", "awesome.txt")))
 #> OMG this is so awesome!
 ```
@@ -95,7 +95,7 @@ the path to `awesome.txt`, still works.
 ``` r
 setwd(here("one"))
 getwd()
-#> [1] "/Users/jenny/rrr/here_here/one"
+#> [1] "/Users/amanda/Desktop/Projects/here_here/one"
 cat(readLines(here("one", "two", "awesome.txt")))
 #> OMG this is so awesome!
 ```
@@ -128,5 +128,5 @@ fallback. Use `set_here()` to create an empty `.here` file that will
 stop the search if none of the other criteria apply. `dr_here()` will
 attempt to explain why `here` decided the root location the way it did.
 See the [function
-reference](https://krlmlr.github.io/here/reference/here.html) for more
+reference](https://github.com/r-lib/here/blob/master/R/here.R) for more
 detail.

--- a/README.md
+++ b/README.md
@@ -74,16 +74,16 @@ displays this on load or, at any time, you can just call `here()`.
 
 ``` r
 library(here)
-#> here() starts at /Users/amanda/Desktop/Projects/here_here
+#> here() starts at /Users/jenny/rrr/here_here
 here()
-#> [1] "/Users/amanda/Desktop/Projects/here_here"
+#> [1] "/Users/jenny/rrr/here_here"
 ```
 
 Build a path to something in a subdirectory and use it.
 
 ``` r
 here("one", "two", "awesome.txt")
-#> [1] "/Users/amanda/Desktop/Projects/here_here/one/two/awesome.txt"
+#> [1] "/Users/jenny/rrr/here_here/one/two/awesome.txt"
 cat(readLines(here("one", "two", "awesome.txt")))
 #> OMG this is so awesome!
 ```
@@ -95,7 +95,7 @@ the path to `awesome.txt`, still works.
 ``` r
 setwd(here("one"))
 getwd()
-#> [1] "/Users/amanda/Desktop/Projects/here_here/one"
+#> [1] "/Users/jenny/rrr/here_here/one"
 cat(readLines(here("one", "two", "awesome.txt")))
 #> OMG this is so awesome!
 ```


### PR DESCRIPTION
Hi! I noticed the links to the here package are a bit out of date. I wasn't totally sure which link was meant for the [`function reference`](https://github.com/jennybc/here_here/compare/master...aedobbyn:master#diff-04c6e90faac2675aa89e2176d2eec7d8L131) so the one I changed it to might not be what you had in mind :)